### PR TITLE
Set RTP Marker on all buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The package can be installed by adding `membrane_rtp_aac_plugin` to your list of
 ```elixir
 def deps do
   [
-    {:membrane_rtp_aac_plugin, "~> 0.9.6"}
+    {:membrane_rtp_aac_plugin, "~> 0.9.7"}
   ]
 end
 ```

--- a/lib/membrane_element_rtp_aac/payloader.ex
+++ b/lib/membrane_element_rtp_aac/payloader.ex
@@ -48,7 +48,13 @@ defmodule Membrane.RTP.AAC.Payloader do
           do: acc = [au | state.acc],
           packet_ready?: true <- length(acc) == state.frames_per_packet do
       acc = Enum.reverse(acc)
-      new_buffer = %Buffer{buffer | payload: wrap_aac(acc, state)}
+
+      new_buffer = %Buffer{
+        buffer
+        | payload: wrap_aac(acc, state),
+          metadata: Map.put(buffer.metadata, :rtp, %{marker: true})
+      }
+
       {[buffer: {:output, new_buffer}], %{state | acc: []}}
     else
       validate_size: false -> raise "Received frames are too long for the chosen bitrate mode"

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTP.AAC.Mixfile do
   use Mix.Project
 
-  @version "0.9.6"
+  @version "0.9.7"
   @github_url "https://github.com/membraneframework/membrane_rtp_aac_plugin"
 
   def project do


### PR DESCRIPTION
According to https://www.rfc-editor.org/rfc/rfc3640#section-3.1, it should be set on all buffers, since they contain complete Access Units